### PR TITLE
use ci friendly variables in maven build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ For [GitHubFlow](https://guides.github.com/introduction/flow/) try the same usin
 export GITVERSION_SEMVER=$(docker-compose run gitversion | tr -dc '[[:print:]]')
 docker-compose build maven
 ```
+
+### Maven
+Maven uses the special *${revision}* variable to set the version, see https://maven.apache.org/maven-ci-friendly.html .
+
+The [flatten-maven-plugin](https://www.mojohaus.org/flatten-maven-plugin/) is needed, if you want to install/deploy the build artifact.

--- a/maven/.gitignore
+++ b/maven/.gitignore
@@ -1,1 +1,2 @@
 /target/**
+.flattened-pom.xml

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -3,6 +3,4 @@ ARG GITVERSION_SEMVER=0.1.0-unknown
 RUN mkdir -p /usr/app
 WORKDIR /usr/app
 ADD . ./
-RUN mvn versions:set -DnewVersion=${GITVERSION_SEMVER} &&\
- mvn versions:commit &&\
- mvn package
+RUN mvn -Drevision=${GITVERSION_SEMVER} package

--- a/maven/buildMaven.bat
+++ b/maven/buildMaven.bat
@@ -1,3 +1,3 @@
 @echo off
-mvn mvn versions:set -DnewVersion=%GitVersion_SemVer% && mvn versions:commit && mvn package
+mvn -Drevision=%GitVersion_SemVer% clean package
 endlocal

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -3,11 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gitversion.examples</groupId>
   <artifactId>hello.gitversion</artifactId>
-  <version>0.0.1-unknown</version>
+  <version>${revision}</version>
 
   <properties>
+    <revision>0.0.1-unknown</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
-  
+
 </project>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -11,4 +11,32 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Since maven version 3.5 special variables are supported for version in maven's `pom.xml`.

This pull request uses the *${revision}* variable for the version, which can be set on command line during build with

    mvn -Drevision=1.0.1 clean package

Changing the `pom.xml` with the versions plugin is not needed anymore.

See also https://maven.apache.org/maven-ci-friendly.html